### PR TITLE
fix: use builder instead of parsing URI directly from a string

### DIFF
--- a/src/main/scala/repo/RedisImpl.scala
+++ b/src/main/scala/repo/RedisImpl.scala
@@ -37,10 +37,14 @@ class RedisImpl(channel: Channel, client: RedisClient) extends Store(channel) {
     Try {
       client.connect()
     } match {
-      case Failure(exception) => RedisConnectionError(exception.toString).asLeft.pure[Task]
+      case Failure(exception) => {
+        logger.error(s"Error while connecting to Redis: ${exception.toString}")
+        RedisConnectionError(exception.toString).asLeft.pure[Task]
+      }
       case Success(con) =>
         connection = Some(con)
         commands = Some(con.sync())
+        logger.info("Successfully connected to Redis")
         ().asRight.pure[Task]
     }
   }


### PR DESCRIPTION
# Why
- The connection URI seems being parsed wrongly (host: [xxx.xxx.xxx:6379], port: 6379)

# What
- Use builder to be able to pass exact value instead of relying on the URI parser (from RedisURI)

# PoW
Added `println` lines to see if the connection is created successfully or not
```scala
  override def connect(): Task[Either[AppError, Unit]] = {
    Try {
      client.connect()
    } match {
      case Failure(exception) => {
        println(s"failed, exception=[${exception}]")
        RedisConnectionError(exception.toString).asLeft.pure[Task]
      }
      case Success(con) =>
        connection = Some(con)
        commands = Some(con.sync())
        println(s"commands=[${commands}]")
        ().asRight.pure[Task]
    }
  }
```

```sh
java -cp target/scala-2.13/guardian-mds-mme-translator-assembly-0.82.jar com.guardian.Main
commands=[Some(io.lettuce.core.FutureSyncInvocationHandler@6928013b)]
```